### PR TITLE
Improve type-check time for EntitiesInText

### DIFF
--- a/Sources/Clustering/Structs.swift
+++ b/Sources/Clustering/Structs.swift
@@ -8,7 +8,11 @@ public struct EntitiesInText : Equatable {
         return "PER[" + entities["PersonalName"]!.description + "] - LOC[" + entities["PlaceName"]!.description + "] - ORG[" + entities["OrganizationName"]!.description + "]"
     }
     var isEmpty: Bool {
-        if (entities["PersonalName"]?.count ?? 0) + (entities["PlaceName"]?.count ?? 0) + (entities["OrganizationName"]?.count ?? 0) == 0 {
+        let personalName = entities["PersonalName"]?.count ?? 0
+        let placeName = entities["PlaceName"]?.count ?? 0
+        let organizationName = entities["OrganizationName"]?.count ?? 0
+        let total = personalName + placeName + organizationName
+        if total == 0 {
             return true
         } else {
             return false


### PR DESCRIPTION
On a fresh clone of the project trying to build Clustering with Xcode 16 I get this error:

<img width="798" alt="Screenshot 2024-11-28 at 01 07 34" src="https://github.com/user-attachments/assets/ae083b9d-f43f-4ae8-9ab3-ae6fbb170549">

Simply breaking up in multiple lines helps the compiler 